### PR TITLE
Update deprecated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.4",
   "license": "MIT",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "author": "Daniel Imfeld",


### PR DESCRIPTION
Using the svelte field in package.json to point at .svelte source files is deprecated and will be removed. https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition